### PR TITLE
Add configuration for authority processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,30 @@ The configuration file's format is JSON, and has the following structure (see `c
     "query" : "SQL query used to fetch documents",
     "chunkSize" : 20000,
     "solrUrl" : "http://localhost:8983/solr/trlnbib",
+    "authorities": true,
+    "redisUrl": "redis://localhost:6379/0",
     "workers" : 3
 }
 ```
 
-Where the value in the sample above looks like a sensible value, it's the default; you MUST provide at least `password`.  `workers` defaults to the number simultaneous threads the current machine can run (never lower than 1).  The default value for `query` select all non-deleted documents from the database.
+Where the value in the sample above looks like a sensible value, it's the
+default; you MUST provide at least `password`.  `workers` defaults to the
+number simultaneous threads the current machine can run (never lower than 1).
+The default value for `query` select all non-deleted documents from the
+database.
 
-The master process loops over the documents matching the query, and outputs them into files with no more than `chunkSize` records in them.  At  that point, it passes that file to an available worker, which then runs `argot ingest -s [solrUlr]` on the file, which flattens and suffixes the Argot records in the file, and then submits the results to Solr for reindex.
+Authority processing against a redis database (the `authorities` attribute)
+is `true` by default. Note that errors in this process (due to an incorrect
+`redisUrl` property) will only be seen at the point of running the `argot`
+command, so pay attention to the logs
+
+The master process loops over the documents matching the query, and outputs
+them into files with no more than `chunkSize` records in them.  At  that point,
+it passes that file to an available worker, which then runs `argot ingest -s
+[solrUlr] -a --redis-url [redisUrl]` on the file (assuming `authorities` is
+true; if `false` omit the `-a`, `--redis-url` and redis URL parameters), which
+flattens and suffixes the Argot records in the file, and then submits the
+results to Solr for reindex.
 
 The entire process is logged to STDERR, so you may want to run the driver program thusly:
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	Query     string `json:"query"`     // query to use to fetch documents (default: evertying that isn't deleted)
 	ChunkSize int    `json:"chunkSize"` // number of documents in each package
 	SolrUrl   string `json:"solrUrl"`   // base url to solr collection
+    RedisUrl  string `json:"redisUrl"`  // URL to Redis instance
+    Authorities bool `json:"authorities"` // whether to do authority processing
 	Workers   int    `json:"workers"`   // number of concurrent workers (cpu count -1)
 }
 
@@ -59,10 +61,13 @@ func LoadConfig(files ...string) (*Config, error) {
 		Port:      5432,
 		User:      "shrindex",
 		Database:  "shrindex",
-		Query:     "select id, txn_id, owner, content from documents WHERE NOT deleted",
+		Query:     "select id, txn_id, owner, content from documents WHERE NOT deleted ORDER BY id ASC",
 		SolrUrl:   "http://localhost:8983/solr/trlnbib",
 		ChunkSize: 20000,
-		Workers:   runtime.NumCPU() - 1}
+		Workers:   runtime.NumCPU() - 1,
+        Authorities: true,
+        RedisUrl: "redis://localhost:6379/0"}
+        
 	if conf.Workers < 1 {
 		conf.Workers = 1
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/trln/reindexer
+
+go 1.19
+
+require (
+	github.com/jmoiron/sqlx v1.3.5
+	github.com/lib/pq v1.10.7
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
+github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -6,7 +6,15 @@ import (
 	"os/exec"
 )
 
-func Ingest(filename string, solrUrl string) error {
+// configuration specifically for
+// ingest operations.
+type IngestConfig struct {
+    SolrUrl string
+    Authorities bool
+    RedisUrl string
+}
+
+func Ingest(filename string, config IngestConfig ) error {
 	log.Println("Ingesting ", filename)
 	defer func() {
 		err := os.Remove(filename)
@@ -16,7 +24,12 @@ func Ingest(filename string, solrUrl string) error {
 	}()
 
 	defer log.Println("Completed work on ", filename)
-	cmd := exec.Command("argot", "ingest", "-s", solrUrl, filename)
+    var cmd *exec.Cmd
+    if config.Authorities {
+        cmd = exec.Command("argot", "ingest", "-a", "--redis-url", config.RedisUrl, "-s", config.SolrUrl, filename)
+    } else {
+	    cmd = exec.Command("argot", "ingest", "-s", config.SolrUrl, filename)
+    }
 	combined, err := cmd.CombinedOutput()
 	if combined != nil {
 		log.Println("[", filename, "] argot output ", string(combined))


### PR DESCRIPTION
Adds `authorities` and `redisUrl` configuration properties to add authority processing from `argot-ruby` v1.1.0
Reorganizes code to use go modules.
